### PR TITLE
Typecasted null variable as array for foreach loop

### DIFF
--- a/loopee/pi.loopee.php
+++ b/loopee/pi.loopee.php
@@ -216,7 +216,7 @@ class Loopee {
      * Do the foreach bit for every single value that was piped.
      */
     $loopee_count = 1;
-    foreach ($this->params['foreach'] as $key => $value)
+    foreach ((array)$this->params['foreach'] as $key => $value)
     {
       // Replace all the {keys} and {values} in one fancy preg_replace.
       $this->return_data .= preg_replace(array($key_regex,$value_regex,$count_regex), array($key,$value,$loopee_count), $tagdata);


### PR DESCRIPTION
PHP (not sure starting which version) would give the following error:

A PHP Error was encountered

Severity: Warning

Message: Invalid argument supplied for foreach()

Filename: loopee/pi.loopee.php

Line Number: 219
